### PR TITLE
Change the package name to jupyter_paperboy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open(path.join(here, 'requirements.txt'), encoding='utf-8') as f:
         requires.append('waitress')
 
 setup(
-    name='paperboy',
+    name='jupyter_paperboy',
     version='0.0.3',
     description='Jupyter notebooks',
     long_description=long_description,


### PR DESCRIPTION
We will still import as `paperboy`.  cf #67 